### PR TITLE
Issue #32: update validateStoneSysNodes to take stoneName as optional

### DIFF
--- a/tode/sys/default/bin/validateStoneSysNodes.ston
+++ b/tode/sys/default/bin/validateStoneSysNodes.ston
@@ -5,20 +5,25 @@ TDScriptLeafNode{#name:'validateStoneSysNodes',#contents:'[ :topez :objIn :token
     getOptsMixedLongShort:
       {#(\'help\' $h #\'none\').
       #(\'files\' nil #\'none\').
-      #(\'repair\' nil #\'none\')}
+      #(\'repair\' nil #\'none\').
+      #(\'stone\' nil #\'required\')}
     optionsAndArguments: [ :options :operands | 
       opts := options.
       args := operands ].
   opts
     at: \'help\'
     ifAbsent: [ 
-      | validateDirBlock validateFileBlock stoneRoot stoneRootDir repair rootDir dir cpTool |
+      | validateDirBlock validateFileBlock stoneRoot stoneRootDir repair rootDir dir cpTool stoneName |
+      cpTool := topez toolInstanceFor: \'cp\'.
       opts
         at: \'repair\'
         ifPresent: [ :ignored | repair := true ]
         ifAbsent: [ repair := false ].
-      cpTool := topez toolInstanceFor: \'cp\'.
-      stoneRoot := topez serverTodeStoneRoot.
+      opts
+        at: \'stone\'
+        ifPresent: [ :name | stoneName := name ]
+        ifAbsent: [ stoneName := topez serverStoneName ].
+      stoneRoot := topez serverTodeStoneRootFor: stoneName.
       stoneRootDir := ServerFileDirectory on: stoneRoot.
       validateDirBlock := [ :dir | 
       dir exists
@@ -30,7 +35,10 @@ TDScriptLeafNode{#name:'validateStoneSysNodes',#contents:'[ :topez :objIn :token
       (dir fileExists: filename)
         ifFalse: [ 
           repair
-            ifTrue: [ cpTool cp: \'/sys/stones/templates/\' , nodename to: \'/sys/stone\' ]
+            ifTrue: [ 
+              cpTool
+                cp: \'/sys/stones/templates/\' , nodename
+                to: \'/sys/stones/stones/\' , stoneName, \'/root/\' ]
             ifFalse: [ 
               self
                 error:
@@ -61,10 +69,14 @@ TDScriptLeafNode{#name:'validateStoneSysNodes',#contents:'[ :topez :objIn :token
           \'NAME
   validateStoneSysNodes - validateStoneSysNodes sript utility template
 SYNOPSIS
-  validateStoneSysNodes [-h|--help] [--files] [--repair]
+  validateStoneSysNodes [-h|--help] [--stone=<stone-name>] [--files] [--repair]
+
 DESCRIPTION
-  Verifies that the minimal per-stone directory structure exists. In the following
-  the minimal per-stone directory structure is shown at <stone-name> and below:
+  Verifies that the minimal per-stone directory structure exists for the given stone. By default
+  the currently running stone is validated. If the --stone option is used, then the directory
+  structure for <stone-name> is validated.
+
+  In the following the minimal per-stone directory structure is shown at <stone-name> and below:
 
   +-$GS_HOME\\
     +-tode\\
@@ -85,7 +97,7 @@ DESCRIPTION
   projectComposition.ston files are copies of the files in 
   $GS_HOME/tode/sys/stones/templates.
 
-  With no options, and error is thrown if the directories are missing.
+  With no options, an error is thrown if the directories are missing.
 
   With the --files option an error is also thrown if either of the files are missing.
 
@@ -100,5 +112,7 @@ EXAMPLES
   /sys/default/bin/validateStoneSysNodes --files
   /sys/default/bin/validateStoneSysNodes --repair
   /sys/default/bin/validateStoneSysNodes --files --repair
+  /sys/default/bin/validateStoneSysNodes --stone=gsDevKit --repair
+  /sys/default/bin/validateStoneSysNodes --stone=gsDevKit --files --repair
 \'
-        topez: topez ] ]',#creationTime:DateAndTime['2014-11-14T16:19:26.4569790363311-08:00'],#modificationTime:DateAndTime['2014-11-15T16:05:37.0675010681152-08:00']}
+        topez: topez ] ]',#creationTime:DateAndTime['2014-11-14T16:19:26.4569790363311-08:00'],#modificationTime:DateAndTime['2014-11-17T09:31:25.0474090576171-08:00']}

--- a/tode/sys/default/client/scripts/installServerTode2
+++ b/tode/sys/default/client/scripts/installServerTode2
@@ -4,10 +4,8 @@ mount --todeRoot sys/default /sys default
 mount --todeRoot sys/local /sys local
 mount --todeRoot sys/stones /sys stones
 # ensure that --stoneRoot directory structure is present
-/sys/default/bin/validateStoneSysNodes --repair
-mount --stoneRoot root /sys stone
-# ensure that --stoneRoot file structure is present
 /sys/default/bin/validateStoneSysNodes --files --repair
+mount --stoneRoot root /sys stone
 # Define /home and /projects based on a composition of the /sys nodes
 mount --stoneRoot root/homeComposition.ston / home
 mount --stoneRoot root/projectComposition.ston / projects


### PR DESCRIPTION
arg so it can be used to build stone structure BEFORE starting stone and
stream-line installServerTode2 script since validateStoneSysNodes is no
longer dependent upon /sys/stone existing [ci skip]
